### PR TITLE
feat: 增強使用者登入系統 - 方案 A

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -246,8 +246,8 @@
             <!-- 登入表單 -->
             <div class="auth-form" id="loginForm">
                 <div class="form-group">
-                    <label for="loginUsername">用戶名：</label>
-                    <input type="text" id="loginUsername" placeholder="請輸入用戶名">
+                    <label for="loginUsername">用戶名/Email：</label>
+                    <input type="text" id="loginUsername" placeholder="請輸入用戶名或 Email">
                 </div>
                 <div class="form-group">
                     <label for="loginPassword">密碼：</label>
@@ -261,6 +261,12 @@
                         <button type="button" id="refreshLoginCaptcha" class="btn btn-small">重新生成</button>
                     </div>
                 </div>
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" id="rememberMe">
+                        <span>記住我（30 天）</span>
+                    </label>
+                </div>
                 <div class="form-buttons">
                     <button id="loginBtn" class="btn btn-primary">登入</button>
                     <button id="showRegisterBtn" class="btn btn-secondary">註冊新帳號</button>
@@ -271,11 +277,16 @@
             <div class="auth-form" id="registerForm" style="display: none;">
                 <div class="form-group">
                     <label for="registerUsername">用戶名：</label>
-                    <input type="text" id="registerUsername" placeholder="請輸入用戶名">
+                    <input type="text" id="registerUsername" placeholder="請輸入用戶名（必填）">
+                </div>
+                <div class="form-group">
+                    <label for="registerEmail">Email：</label>
+                    <input type="email" id="registerEmail" placeholder="請輸入 Email（選填）">
+                    <small class="form-hint">可用於登入和找回密碼</small>
                 </div>
                 <div class="form-group">
                     <label for="registerPassword">密碼：</label>
-                    <input type="password" id="registerPassword" placeholder="請輸入密碼">
+                    <input type="password" id="registerPassword" placeholder="請輸入密碼（至少 6 個字元）">
                 </div>
                 <div class="form-group">
                     <label for="confirmPassword">確認密碼：</label>

--- a/public/style.css
+++ b/public/style.css
@@ -778,3 +778,72 @@ header {
         transform: scale(0.7);
     }
 }
+
+/* 表單錯誤訊息樣式 */
+.form-error-message {
+    background: #fee;
+    color: #c33;
+    border: 2px solid #fcc;
+    border-radius: 8px;
+    padding: 12px 15px;
+    margin-bottom: 15px;
+    font-size: 14px;
+    font-weight: 500;
+    display: none;
+    animation: slideIn 0.3s ease;
+}
+
+/* 表單成功訊息樣式 */
+.form-success-message {
+    background: #efe;
+    color: #3c3;
+    border: 2px solid #cfc;
+    border-radius: 8px;
+    padding: 12px 15px;
+    margin-bottom: 15px;
+    font-size: 14px;
+    font-weight: 500;
+    display: none;
+    animation: slideIn 0.3s ease;
+}
+
+/* 表單提示樣式 */
+.form-hint {
+    display: block;
+    font-size: 12px;
+    color: #888;
+    margin-top: 5px;
+    font-style: italic;
+}
+
+/* Checkbox 樣式 */
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: auto;
+    cursor: pointer;
+    transform: scale(1.2);
+}
+
+.checkbox-label span {
+    font-weight: normal;
+    color: #555;
+}
+
+/* 滑入動畫 */
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
新增功能：
- ✅ Email 欄位支援（註冊選填，登入可用）
- ✅ 記住我功能（session 延長至 30 天）
- ✅ 改進錯誤處理 UI（友善的提示訊息）

資料庫變更：
- 在 accounts 表新增 email 欄位（UNIQUE, 可選）

後端變更：
- 註冊 API 支援 email 參數並驗證格式
- 登入 API 支援 username 或 email 登入
- 登入 API 支援 rememberMe 參數控制 session 時效

前端變更：
- 登入表單：新增「記住我」checkbox
- 註冊表單：新增 Email 欄位（選填）
- 改進表單驗證（長度、格式、一致性）
- 新增錯誤/成功訊息 UI 組件
- CSS 美化（錯誤框、成功框、checkbox、提示文字）

🤖 Generated with [Claude Code](https://claude.com/claude-code)